### PR TITLE
fix: arrow icons removed; links fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,7 +314,7 @@
         <div>
 
           <div class="flex-v gap-sm legal">
-            <p>IronCalc is developed by <a href="https://www.linkedin.com/in/nicol%C3%A1s-hatcher-5302701a0/" target="_blank">Nicolás Hatcher</a> with lots of help from the designer <a href="https://www.linkedin.com/in/danielgonzalezalbo/" target="_blank">Daniel González-Albo</a>.</p>
+            <p>IronCalc is developed by <a href="https://www.nhatcher.com/" target="_blank">Nicolás Hatcher</a> with lots of help from the designer <a href="https://www.dg-ac.com/" target="_blank">Daniel González-Albo</a>.</p>
             <p>Send us a note at <a href="mailto:hello@ironcalc.com">hello@ironcalc.com</a></p>
           </div>
 

--- a/index.html
+++ b/index.html
@@ -33,13 +33,13 @@
     <nav id="navbar">
       <div class="nav-container">
         <div class="logo w-200">
-          <a href="#home">
+          <a href="index.html#home">
             <img src="images/ironcalc-logo.svg" />
           </a>
         </div>
         <ul>
-          <li><a href="#about">About</a></li>
-          <li><a href="https://docs.ironcalc.com/">Docs <i data-lucide="arrow-up-right"></i></a></li>
+          <li><a href="index.html#about">About</a></li>
+          <li><a href="https://docs.ironcalc.com/">Docs</a></li>
           <li><a href="https://blog.ironcalc.com/">Blog</a></li>
           <li><a href="mailto:hello@ironcalc.com">Contact</a></li>
         </ul>
@@ -59,7 +59,7 @@
 
       <div class="mobile-menu flex-v" id="mobile-menu">
         <a href="#about-mobile">About</a>
-        <a class="flex-h gap-xs" href="https://docs.ironcalc.com/">Docs <i data-lucide="arrow-up-right"></i></a>
+        <a class="flex-h gap-xs" href="https://docs.ironcalc.com/">Docs</a>
         <a href="https://blog.ironcalc.com/">Blog</a>
         <a href="mailto:hello@ironcalc.com">Contact</a>
         <a href="https://app.ironcalc.com" target="_blank"><p class="orange">Try now</p></a>
@@ -95,7 +95,7 @@
           </h2>
           <div class="hero-ctas">
             <a href="https://app.ironcalc.com" target="_blank"><button>Try now</button></a>
-            <a href="https://docs.ironcalc.com" target="_blank"><button class="secondary"><i data-lucide="book-open"></i> Read the docs</button></a>
+            <a href="https://docs.ironcalc.com"><button class="secondary"><i data-lucide="book-open"></i> Read the docs</button></a>
           </div>
         </div>
         <div class="playground-container">
@@ -285,7 +285,7 @@
 
         <div class="flex-h gap-xl a-items-flex-start"  style="justify-content: space-between;">
           <div class="flex-h gap-md" id="footer-logo">
-            <img src="images/ironcalc-logo.svg" style="width: 140px;" />
+            <a href="index.html#scroll-up"><img src="images/ironcalc-logo.svg" style="width: 140px;" /></a>
             <div style="height: 28px;"><a class="github-button" href="https://github.com/ironcalc/ironcalc" data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star ironcalc/ironcalc on GitHub">Star</a>
             </div>
           </div>
@@ -294,7 +294,7 @@
             <div class="flex-v gap-sm w-140">
               <p>Sections</p>
               <a href="https://app.ironcalc.com/">App</a>
-              <a href="#about">About</a>
+              <a href="index.html#about">About</a>
               <a href="https://docs.ironcalc.com/">Docs</a>
               <a href="https://blog.ironcalc.com/">Blog</a>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -77,6 +77,10 @@ a .dark {
   color: var(--dark);
 }
 
+a.active {
+  font-weight: bold;
+}
+
 .hidden {
   opacity: 0;
   pointer-events: none;


### PR DESCRIPTION
Hey Nico, I've fixed a few things here:

- I've removed the arrows next to the Docs and Blog links
- footer logo is now clickable
- adapted some links in the footer
- also replaced the links to our linkedin profiles with links to our personal sites