### PR TITLE
update: Remove sponsors from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,7 @@
         <div>
 
           <div class="flex-v gap-sm legal">
-            <p>IronCalc is developed by <a href="https://www.nhatcher.com/" target="_blank">Nicolás Hatcher</a> with lots of help from the designer <a href="https://www.dg-ac.com/" target="_blank">Daniel González-Albo</a>.</p>
+            <p>IronCalc is developed by <a href="https://www.nhatcher.com/" target="_blank">NH</a> with lots of help from the designer <a href="https://www.dg-ac.com/" target="_blank">DG-AC</a>.</p>
             <p>Send us a note at <a href="mailto:hello@ironcalc.com">hello@ironcalc.com</a></p>
           </div>
 

--- a/index.html
+++ b/index.html
@@ -235,28 +235,6 @@
                   <p>This project is funded through the <a href="https://nlnet.nl/entrust" target="_blank">NGI0 Entrust Fund</a>, a fund established by <a href="https://nlnet.nl/" target="_blank">NLnet</a> with financial support from the European Commission's <a href="https://ngi.eu/" target="_blank">Next Generation Internet</a> program, under the aegis of DG Communications Networks, Content and Technology under grant agreement No 101092990. Learn more on the <a href="https://nlnet.nl/project/IronCalc/" target="_blank">project page</a>.</p>
                 </div>
               </div>
-              
-            </div>
-            <div class="h-divider max-w-920"></div>
-            <div class="flex-h gap-xl max-w-920 w-full">
-              <div class="flex-v gap-sm">
-                <p><strong>Sponsors</strong></p>
-                <p>We are grateful for the support received by the following organizations:</p>
-                <div class="flex-h gap-md">
-                  <a class="grey-container gap-lg" href="https://tuta.com/" target="_blank">
-                    <img class="w-100" src="images/tutanota-logo.svg" />
-                  </a>
-                  <p>Tuta is the world's most secure email service, easy to use and private by design.
-                  </p>
-                </div>
-                <div class="flex-h gap-md">
-                  <a class="grey-container gap-lg" href="https://www.zulip.com/" target="_blank">
-                    <img class="w-100" src="images/zulip-logo.svg" />
-                  </a>
-                  <p>Zulip is an open-source modern team chat app designed to keep both live and asynchronous conversations organized.
-                  </p>
-                </div>
-              </div>
             </div>
       </section>
 


### PR DESCRIPTION
This PR intents to remove the sponsors from the index of ironcalc.com, as these are services we don't use anymore and can lead to misunderstandings. I've also shortened the names in the footer.

`before`
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/b0275ed6-6bf5-41af-8a7c-877ffc4c0c27" />

`after`
<img width="969" alt="image" src="https://github.com/user-attachments/assets/43ef8255-21d5-4085-824e-d6f70bd51268" />

---

**Changes**

- Removed the section 'sponsors' from index
- Shortened the names in footer
