### PR TITLE
fix: text-wrapping and fonts

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1623,7 +1623,8 @@ h4 {
   transition: none;
 }
 
-#use-cases button p {
+#use-cases button p,
+#use-cases button span {
   min-width: 0;
   overflow-wrap: break-word;
   text-wrap: wrap;

--- a/styles.css
+++ b/styles.css
@@ -177,7 +177,7 @@ section.dark .grey-500 {
 /* font-family */
 
 .ff-mozilla {
-  font-family: "Mozilla Headline", sans-serif;
+  font-family: "Mozilla Headline", "Helvetica Neue", Arial, sans-serif;
 }
 
 /* font-weight */
@@ -1862,11 +1862,11 @@ h4 {
 }
 
 #privacy-page .legal-layout-content h1 {
-  font-family: "Mozilla Headline", sans-serif;
+  font-family: "Mozilla Headline", "Helvetica Neue", Arial, sans-serif;
 }
 
 #privacy-page .legal-layout-content h2 {
-  font-family: "Mozilla Headline", sans-serif;
+  font-family: "Mozilla Headline", "Helvetica Neue", Arial, sans-serif;
   font-size: 22px;
   line-height: 110%;
 }


### PR DESCRIPTION
This PR aims for fix:

- A bug by which the text in the use-cases section descriptions didn't wrap
- A better fallback font for headers and titles