### PR TITLE
fix: 404 page assets not loading on URLs with trailing slash

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,11 +7,11 @@
     <meta name="description" content="Page not found - IronCalc">
 
     <!-- Styles -->
-    <link rel="stylesheet" href="styles.css?v=1">
-    <link rel="stylesheet" href="fonts.css">
+    <link rel="stylesheet" href="/styles.css?v=1">
+    <link rel="stylesheet" href="/fonts.css">
 
     <!-- Favicon -->
-    <link rel="icon" href="favicon/favicon-32x32.png">
+    <link rel="icon" href="/favicon/favicon-32x32.png">
   </head>
   <body id="page-404">
     <main class="flex-v a-items-center j-content-center page-404-main">
@@ -21,7 +21,7 @@
           <h1 class="ff-mozilla font-w-500 page-404-title">#REF!</h1>
           <p class="grey-600 text-pretty max-w-440">This page doesn't exist or has been moved.</p>
         </div>
-        <a href="index.html" class="button">Go to homepage</a>
+        <a href="/index.html" class="button">Go to homepage</a>
       </div>
     </main>
   </body>


### PR DESCRIPTION
A trailing slash in the URL was causing an error where the css wasn't being loaded:

<img width="330" height="214" alt="image" src="https://github.com/user-attachments/assets/ea6b84b4-4ad9-4b37-acd6-217d4957b7b3" />
